### PR TITLE
Refactor weather model naming from "forecast" to "prediction"

### DIFF
--- a/openshift/templates/deploy.dc.yaml
+++ b/openshift/templates/deploy.dc.yaml
@@ -24,10 +24,10 @@ parameters:
     value: auzhsi-tools
   - name: CPU_REQUEST
     description: Requested CPU
-    value: 500m
+    value: 750m
   - name: CPU_LIMIT
     description: CPU upper limit
-    value: 500m
+    value: 750m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 1Gi

--- a/src/api/modelAPI.ts
+++ b/src/api/modelAPI.ts
@@ -32,17 +32,17 @@ export interface Model {
 }
 
 export interface ModelsResponse {
-  forecasts: Model[]
+  predictions: Model[]
 }
 
 export async function getModels(stationCodes: number[]): Promise<Model[]> {
-  const url = '/models/GDPS/forecasts/'
+  const url = '/models/GDPS/predictions/'
 
   try {
     const { data } = await axios.post<ModelsResponse>(url, {
       stations: stationCodes
     })
-    return data.forecasts
+    return data.predictions
   } catch (err) {
     throw err.toString()
   }
@@ -77,7 +77,7 @@ export async function getHistoricModels(
   stationCodes: number[],
   model: 'GDPS'
 ): Promise<HistoricModelSummary[]> {
-  const url = `/models/${model}/forecasts/summaries/`
+  const url = `/models/${model}/predictions/summaries/`
   try {
     const { data } = await axios.post<HistoricModelSummariesResponse>(url, {
       stations: stationCodes

--- a/src/features/fireWeather/pages/FireWeatherPage.mock.ts
+++ b/src/features/fireWeather/pages/FireWeatherPage.mock.ts
@@ -8,11 +8,11 @@ export const mockStations = [
 ]
 
 export const emptyModelsResponse = {
-  forecasts: []
+  predictions: []
 }
 
 export const mockModelsResponse: RecursivePartial<ModelsResponse> = {
-  forecasts: [
+  predictions: [
     {
       station: mockStations[0],
       values: [

--- a/src/features/fireWeather/pages/FireWeatherPage.test.tsx
+++ b/src/features/fireWeather/pages/FireWeatherPage.test.tsx
@@ -58,11 +58,11 @@ it('renders weather stations dropdown with data', async () => {
 
 it('renders no data available message if there is no weather data returned', async () => {
   mockAxios.onGet('/stations/').replyOnce(200, { weather_stations: mockStations })
-  mockAxios.onPost('/models/GDPS/forecasts/').replyOnce(200, emptyModelsResponse)
+  mockAxios.onPost('/models/GDPS/predictions/').replyOnce(200, emptyModelsResponse)
   mockAxios.onPost('/hourlies/').replyOnce(200, emptyReadingsResponse)
   mockAxios.onPost('/noon_forecasts/').replyOnce(200, emptyForecastsResponse)
   mockAxios
-    .onPost('/models/GDPS/forecasts/summaries/')
+    .onPost('/models/GDPS/predictions/summaries/')
     .replyOnce(200, emptyHistoricModelsResponse)
   const { getByText, getByTestId, queryByText, queryByTestId } = renderWithRedux(
     <FireWeatherPage />
@@ -97,10 +97,10 @@ it('renders no data available message if there is no weather data returned', asy
 
 it('renders error messages in response to network errors', async () => {
   mockAxios.onGet('/stations/').replyOnce(200, { weather_stations: mockStations })
-  mockAxios.onPost('/models/GDPS/forecasts/').replyOnce(400)
+  mockAxios.onPost('/models/GDPS/predictions/').replyOnce(400)
   mockAxios.onPost('/hourlies/').replyOnce(400)
   mockAxios.onPost('/noon_forecasts/').replyOnce(400)
-  mockAxios.onPost('/models/GDPS/forecasts/summaries/').replyOnce(400)
+  mockAxios.onPost('/models/GDPS/predictions/summaries/').replyOnce(400)
 
   const { getByText, getByTestId, queryByText } = renderWithRedux(<FireWeatherPage />)
 
@@ -129,11 +129,11 @@ it('renders error messages in response to network errors', async () => {
 
 it('renders daily model, forecast, and hourly values in response to user inputs', async () => {
   mockAxios.onGet('/stations/').replyOnce(200, { weather_stations: mockStations })
-  mockAxios.onPost('/models/GDPS/forecasts/').replyOnce(200, mockModelsResponse)
+  mockAxios.onPost('/models/GDPS/predictions/').replyOnce(200, mockModelsResponse)
   mockAxios.onPost('/hourlies/').replyOnce(200, mockReadingsResponse)
   mockAxios.onPost('/noon_forecasts/').replyOnce(200, mockForecastsResponse)
   mockAxios
-    .onPost('/models/GDPS/forecasts/summaries/')
+    .onPost('/models/GDPS/predictions/summaries/')
     .replyOnce(200, mockHistoricModelsResponse)
 
   const { getByText, getByTestId, getAllByTestId } = renderWithRedux(<FireWeatherPage />)


### PR DESCRIPTION
- Changed references from "forecast" to "prediction" to match re-factor on API.