### PR TITLE
Show hourly readings

### DIFF
--- a/openshift/templates/build.bc.yaml
+++ b/openshift/templates/build.bc.yaml
@@ -53,10 +53,10 @@ objects:
           name: ${NAME}-${SUFFIX}:${SUFFIX}
       resources:
         limits:
-          cpu: "2"
+          cpu: "4"
           memory: 5Gi
         requests:
-          cpu: "1"
+          cpu: "2"
           memory: 1Gi
       source:
         git:

--- a/openshift/templates/deploy.dc.yaml
+++ b/openshift/templates/deploy.dc.yaml
@@ -27,7 +27,7 @@ parameters:
     value: 750m
   - name: CPU_LIMIT
     description: CPU upper limit
-    value: 750m
+    value: 1000m
   - name: MEMORY_REQUEST
     description: Requested memory
     value: 1Gi

--- a/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
+++ b/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
@@ -71,7 +71,9 @@ const HourlyReadingsDisplay = ({ values }: Props) => {
               <TableRow>
                 <TableCell>Wind Dir</TableCell>
                 {values.map(v => (
-                  <TableCell key={v.datetime}>{v.wind_direction != null && Math.round(v.wind_direction)}</TableCell>
+                  <TableCell key={v.datetime}>
+                    {v.wind_direction != null && Math.round(v.wind_direction)}
+                  </TableCell>
                 ))}
               </TableRow>
               <TableRow>

--- a/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
+++ b/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
@@ -78,7 +78,7 @@ const HourlyReadingsDisplay = ({ values }: Props) => {
                 <TableCell>Wind Spd (km/h)</TableCell>
                 {values.map(v => (
                   <TableCell key={v.datetime}>
-                    {v.wind_speed.toFixed(HOURLY_VALUES_DECIMAL)}
+                    {v.wind_speed?.toFixed(HOURLY_VALUES_DECIMAL)}
                   </TableCell>
                 ))}
               </TableRow>
@@ -86,7 +86,7 @@ const HourlyReadingsDisplay = ({ values }: Props) => {
                 <TableCell>Precip (mm/cm)</TableCell>
                 {values.map(v => (
                   <TableCell key={v.datetime}>
-                    {v.precipitation.toFixed(HOURLY_VALUES_DECIMAL)}
+                    {v.precipitation?.toFixed(HOURLY_VALUES_DECIMAL)}
                   </TableCell>
                 ))}
               </TableRow>

--- a/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
+++ b/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
@@ -64,14 +64,14 @@ const HourlyReadingsDisplay = ({ values }: Props) => {
                 <TableCell>RH (%)</TableCell>
                 {values.map(v => (
                   <TableCell key={v.datetime}>
-                    {Math.round(v.relative_humidity)}
+                    {v.relative_humidity != null && Math.round(v.relative_humidity)}
                   </TableCell>
                 ))}
               </TableRow>
               <TableRow>
                 <TableCell>Wind Dir</TableCell>
                 {values.map(v => (
-                  <TableCell key={v.datetime}>{Math.round(v.wind_direction)}</TableCell>
+                  <TableCell key={v.datetime}>{v.wind_direction != null && Math.round(v.wind_direction)}</TableCell>
                 ))}
               </TableRow>
               <TableRow>

--- a/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
+++ b/src/features/fireWeather/components/HourlyReadingsDisplay.tsx
@@ -56,7 +56,7 @@ const HourlyReadingsDisplay = ({ values }: Props) => {
                 <TableCell>Temp (°C)</TableCell>
                 {values.map(v => (
                   <TableCell key={v.datetime}>
-                    {v.temperature.toFixed(HOURLY_VALUES_DECIMAL)}
+                    {v.temperature?.toFixed(HOURLY_VALUES_DECIMAL)}
                   </TableCell>
                 ))}
               </TableRow>


### PR DESCRIPTION
- modify hourly readings table to handle null values.
- increased cpu allocation for build (hoping for faster builds).
- slightly increased cpu limit for deployment (hoping for faster startup).